### PR TITLE
Sphinx 빌드에서 venv 파일 제외

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -137,6 +137,9 @@ language = None
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 exclude_patterns += sphinx_gallery_conf['examples_dirs']
 exclude_patterns += ['*/index.rst']
+exclude_patterns += ['venv']
+exclude_patterns += ['virtualenv']
+exclude_patterns += ['ENV']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = 'sphinx'


### PR DESCRIPTION
## 라이선스 동의
- [x] 기여하기 문서를 확인하였으며, 본 PR 내용에 BSD 3항 라이선스가 적용됨에 동의합니다.

## 관련 이슈 번호

- **이슈 번호**: #126

## PR 종류

- [x] 위 종류에 포함되지 않는 기여

## PR 설명

`make html-noplot` 혹은 다른 Sphinx 빌드를 할때 ./venv, ./virtualenv, ./ENV 폴더를 무시합니다