### PR TITLE
fix Typo in intermediate_source/dist_tuto.rst

### DIFF
--- a/intermediate_source/dist_tuto.rst
+++ b/intermediate_source/dist_tuto.rst
@@ -208,16 +208,16 @@ PyTorch에 포함된 분산 패키지(예. ``torch.distributed``)는 연구자�
 PyTorch에는 현재 ``dist.all_reduce(tensor, op, group)`` 외에도 6개의 집합 통신이
 구현되어 있습니다.
 
--  ``dist.broadcast(tensor, src, group)``: ``src`` 의 ``tensor`` 를 모든 프로세스에
+-  ``dist.broadcast(tensor, src, group)``: ``src`` 의 ``tensor`` 를 모든 프로세스의 ``tensor`` 에
    복사합니다.
 -  ``dist.reduce(tensor, dst, op, group)``: ``op`` 를 모든 ``tensor`` 에 적용한 뒤
-   결과를 ``dst`` 에 저장합니다.
+   결과를 ``dst`` 프로세스의 ``tensor`` 에 저장합니다.
 -  ``dist.all_reduce(tensor, op, group)``: 리듀스와 동일하지만, 결과가 모든
-   프로세스에 저장됩니다.
+   프로세스의 ``tensor`` 에 저장됩니다.
 -  ``dist.scatter(tensor, scatter_list, src, group)``: :math:`i^{\text{번째}}` Tensor
-   ``scatter_list[i]`` 를 :math:`i^{\text{번째}}` 프로세스에 복사합니다.
--  ``dist.gather(tensor, gather_list, dst, group)``: ``dst`` 의 모든 프로세스에서
-   ``tensor`` 를 복사합니다.
+   ``scatter_list[i]`` 를 :math:`i^{\text{번째}}` 프로세스의 ``tensor`` 에 복사합니다.
+-  ``dist.gather(tensor, gather_list, dst, group)``: 모든 프로세스의 ``tensor`` 를 ``dst`` 프로세스의
+   ``gather_list`` 에 복사합니다.
 -  ``dist.all_gather(tensor_list, tensor, group)``: 모든 프로세스의 ``tensor`` 를
    모든 프로세스의 ``tensor_list`` 에 복사합니다.
 -  ``dist.barrier(group)``: `group` 내의 모든 프로세스가 이 함수에 진입할 때까지


### PR DESCRIPTION
- Fix translation typo in intermediate_source/dist_tuto.rst

Opened at issue #321

## 라이선스 동의
_변경해주시는 내용에 BSD 3항 라이선스가 적용됨을 동의해주셔야 합니다._<br />
_더 자세한 내용은 [기여하기 문서](https://github.com/9bow/PyTorch-tutorials-kr/blob/master/CONTRIBUTING.md)를 참고해주세요._<br />
_동의하시면 아래 `[ ]`를 `[x]`로 만들어주세요._<br />

- [x] 기여하기 문서를 확인하였으며, 본 PR 내용에 BSD 3항 라이선스가 적용됨에 동의합니다.

## 관련 이슈 번호
_이 Pull Request와 관련있는 이슈 번호를 적어주세요._<br />
_이슈 또는 PR 번호 앞에 #을 붙이시면 제목을 바로 확인하실 수 있습니다. (예. #999 )_

- **이슈 번호**: #321

## PR 종류
_이 PR에 해당되는 종류 앞의 `[ ]`을 `[x]`로 변경해주세요._<br />
- [x] 오탈자를 수정하거나 번역을 개선하는 기여
- [ ] 번역되지 않은 튜토리얼을 번역하는 기여
- [ ] 공식 튜토리얼 내용을 반영하는 기여
- [ ] 위 종류에 포함되지 않는 기여

## PR 설명
_이 PR로 무엇이 달라지는지 대략적으로 알려주세요._

기존 번역을 수정하였습니다. 빌드 해서 확인한 결과를 올립니다. 감사합니다.

![image](https://user-images.githubusercontent.com/31476895/133367880-898fe93f-efdb-464c-830f-016f6a0367cc.png)
